### PR TITLE
Support for Python 3 type hints in decorated methods

### DIFF
--- a/src/visitor.py
+++ b/src/visitor.py
@@ -50,7 +50,7 @@ class Dispatcher(object):
   def __init__(self, param_name, fn):
     frame = inspect.currentframe().f_back.f_back
     top_level = frame.f_locals == frame.f_globals
-    self.param_index = inspect.getargspec(fn).args.index(param_name)
+    self.param_index = self.__argspec(fn).args.index(param_name)
     self.param_name = param_name
     self.targets = {}
 
@@ -67,3 +67,11 @@ class Dispatcher(object):
 
   def add_target(self, typ, target):
     self.targets[typ] = target
+
+  @staticmethod
+  def __argspec(fn):
+    # Support for Python 3 type hints requires inspect.getfullargspec
+    if hasattr(inspect, 'getfullargspec'):
+      return inspect.getfullargspec(fn)
+    else:
+      return inspect.getargspec(fn)


### PR DESCRIPTION
This pull request fixes the following bug related to Python 3 type hints in decorated methods:

```
$ python3 --version
Python 3.2.3
$ cat > bug_demo.py
import visitor

class Node:
  pass

class ExampleVisitor:
  @visitor.on('node')
  def visit(self, node:Node):
    pass

$ python3 bug_demo.py
Traceback (most recent call last):
  File "bug_demo.py", line 6, in <module>
    class ExampleVisitor:
  File "bug_demo.py", line 8, in ExampleVisitor
    def visit(self, node:Node):
  File "/home/benjamin/pyvisitor/src/visitor.py", line 29, in f
    dispatcher = Dispatcher(param_name, fn)
  File "/home/benjamin/pyvisitor/src/visitor.py", line 53, in __init__
    self.param_index = inspect.getargspec(fn).args.index(param_name)
  File "/usr/lib/python3.2/inspect.py", line 809, in getargspec
    raise ValueError("Function has keyword-only arguments or annotations"
ValueError: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them
```
