### PR TITLE
Update visitor.py to use proper iterator method

### DIFF
--- a/src/visitor.py
+++ b/src/visitor.py
@@ -62,7 +62,7 @@ class Dispatcher(object):
     else:
       issub = issubclass
       t = self.targets
-      ks = t.iterkeys()
+      ks = iter(t)
       return [t[k](*args, **kw) for k in ks if issub(typ, k)]
 
   def add_target(self, typ, target):


### PR DESCRIPTION
Use the correct method for iterating dictionary keys.
As there is no dict.iterkeys() in python3, use iter(dict) instead, as it is in the common subset of python 2 and 3.
This is also recommended by:
https://www.python.org/dev/peps/pep-0469/#migrating-to-the-common-subset-of-python-2-and-3